### PR TITLE
New Template: avoid SmartSet error

### DIFF
--- a/ResponsiveLettering.roboFontExt/lib/mathShape/cmd_prepareNewShape.py
+++ b/ResponsiveLettering.roboFontExt/lib/mathShape/cmd_prepareNewShape.py
@@ -1,15 +1,22 @@
+import mojo
+import time
 import vanilla
-from mojo.canvas import Canvas
 from AppKit import NSNumberFormatter
 from defconAppKit.windows.baseWindow import BaseWindowController
-from mojo.UI import *
+from mojo.UI import CurrentFontWindow
+
+# the location of smart sets has moved in RF3:
+rf_version = mojo.roboFont.version
+if int(rf_version[0]) >= 3:
+    from mojo.smartSet import SmartSet
+else:
+    from mojo.UI import SmartSet
 
 """
 
     Make a new UFO and give it the appropriate glyphs and layers.
     
 """
-import os, time
 
 designSpaceModelLibKey = "com.letterror.mathshape.designspace"
 

--- a/ResponsiveLettering.roboFontExt/lib/mathShape/makePage.py
+++ b/ResponsiveLettering.roboFontExt/lib/mathShape/makePage.py
@@ -60,6 +60,7 @@ setInterval(function () {
 			f = codecs.open(svgPath, 'r', 'utf-8')
 			svgData = f.read()
 			svgLoaderContainer.append(svgData)
+			f.close()
 
 		# paste
 		self.html = self.html.replace("//mathshape", js)

--- a/lib/mathShape/cmd_prepareNewShape.py
+++ b/lib/mathShape/cmd_prepareNewShape.py
@@ -1,15 +1,22 @@
+import mojo
+import time
 import vanilla
-from mojo.canvas import Canvas
 from AppKit import NSNumberFormatter
 from defconAppKit.windows.baseWindow import BaseWindowController
-from mojo.UI import *
+from mojo.UI import CurrentFontWindow
+
+# the location of smart sets has moved in RF3:
+rf_version = mojo.roboFont.version
+if int(rf_version[0]) >= 3:
+    from mojo.smartSet import SmartSet
+else:
+    from mojo.UI import SmartSet
 
 """
 
     Make a new UFO and give it the appropriate glyphs and layers.
     
 """
-import os, time
 
 designSpaceModelLibKey = "com.letterror.mathshape.designspace"
 

--- a/lib/mathShape/makePage.py
+++ b/lib/mathShape/makePage.py
@@ -60,6 +60,7 @@ setInterval(function () {
 			f = codecs.open(svgPath, 'r', 'utf-8')
 			svgData = f.read()
 			svgLoaderContainer.append(svgData)
+			f.close()
 
 		# paste
 		self.html = self.html.replace("//mathshape", js)


### PR DESCRIPTION
In RF3, Smart Sets have moved to mojo.smartSet (mojo.UI in 1.8).
To keep the extension alive in RF1.8, I have included an if/else statement (rather ugly unfortunately).

I have also removed unused imports (`os`, `Canvas`), and made a `*` import more specific.

The question is: should the extension live on with RF1.8 in mind?
Creating a new template works in 1.8, but I get this error which doesn’t really look simple to debug:

<img width="532" alt="image" src="https://user-images.githubusercontent.com/2049645/82728175-347dd500-9cef-11ea-9c51-1d47c81118a7.png">
